### PR TITLE
Sanitize OAuth refresh token

### DIFF
--- a/src/lib/har_sanitize.tsx
+++ b/src/lib/har_sanitize.tsx
@@ -31,6 +31,7 @@ const defaultWordList = [
 	"fcParams",
 	"id_token",
 	"password",
+	"refresh_token",
 	"serverData",
 	"shdf",
 	"state",


### PR DESCRIPTION
Any Refresh Token Grant flows captured in a HAR file will include the `refresh_token` (in addition to `client_id` and `client_secret` which are correctly being sanitized). The refresh token is typically long lived and needs to be sanitized.