### PR TITLE
Update 'value' after 'name' regex

### DIFF
--- a/src/lib/har_sanitize.tsx
+++ b/src/lib/har_sanitize.tsx
@@ -76,7 +76,7 @@ function buildRegex(word: string) {
 		// }
 		{
 			regex: new RegExp(
-				`("name": "${word}",[\\s\\w+:"-\\%!*()\`~'.,#]*?"value": ")([\\w+-_:&\\+=#~/$()\\.\\,\\*\\!|%"'\\s;{}]+?)("[\\s]+){1}`,
+				`("name": "${word}",[\\s\\w+:"-\\%!*()\`~'.,#]*?"value": ")((?:\\\\"|[^"])*?)(")`,
 				"g",
 			),
 			replacement: `$1[${word} redacted]$3`,


### PR DESCRIPTION
Attempts to simplify the capture by storing a value of 'anything up to a (non escaped) quote'.

Might:
- fix #22 
- fix #37 
- fix #14 

I tested this with as many HARs as I could generate and didn't run into issues... but... there's certainly the possibility that I missed a scenario.