### PR TITLE
feat: Add inline key-value pair detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"prettier": "prettier . --write",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@radix-ui/react-portal": "^1.0.4",

--- a/src/components/Sanitizer.tsx
+++ b/src/components/Sanitizer.tsx
@@ -19,6 +19,7 @@ const defaulScrubState: ScrubState = {
 	queryArgs: {},
 	postParams: {},
 	mimeTypes: {},
+	inlineKvPairs: {},
 };
 
 export type ScrubState = Record<ScrubType, Record<string, boolean>>;
@@ -27,7 +28,8 @@ export type ScrubType =
 	| "headers"
 	| "queryArgs"
 	| "postParams"
-	| "mimeTypes";
+	| "mimeTypes"
+	| "inlineKvPairs";
 
 function getScrubableItems(input: string): ScrubState {
 	const rawItems = getHarInfo(input);
@@ -62,6 +64,9 @@ export const Sanitizer = () => {
 			if (val) words.add(key);
 		});
 		Object.entries(scrubItems.postParams).map(([key, val]) => {
+			if (val) words.add(key);
+		});
+		Object.entries(scrubItems.inlineKvPairs).map(([key, val]) => {
 			if (val) words.add(key);
 		});
 

--- a/src/components/ScrubChooser.tsx
+++ b/src/components/ScrubChooser.tsx
@@ -15,6 +15,7 @@ const typeMap: Record<ScrubType, string> = {
 	headers: "Headers",
 	postParams: "Post Body Params",
 	queryArgs: "Query String Parameters",
+	inlineKvPairs: "Inline Key Value Pairs",
 };
 
 export const ScrubChooser: React.FC<ScrubChooserProps> = ({

--- a/src/lib/har_sanitize.test.ts
+++ b/src/lib/har_sanitize.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { extractInlineKvKeys, getHarInfo, sanitize } from "./har_sanitize";
+
+describe("extractInlineKvKeys", () => {
+	it("extracts keys from inline key=value pairs", () => {
+		const input = `"value": "client_secret=mysupersecret&client_id=app123"`;
+		const keys = extractInlineKvKeys(input);
+		expect(keys).toEqual(["client_id", "client_secret"]);
+	});
+
+	it("filters out keys longer than 64 characters", () => {
+		const longKey = "a".repeat(65);
+		const input = `"value": "${longKey}=value&short_key=value"`;
+		const keys = extractInlineKvKeys(input);
+		expect(keys).toEqual(["short_key"]);
+	});
+
+	it("returns empty array when no keys found", () => {
+		const input = `"value": "no key value pairs here"`;
+		const keys = extractInlineKvKeys(input);
+		expect(keys).toEqual([]);
+	});
+
+	it("deduplicates keys", () => {
+		const input = `"value": "token=abc&token=def"`;
+		const keys = extractInlineKvKeys(input);
+		expect(keys).toEqual(["token"]);
+	});
+
+	it("extracts keys with hyphens", () => {
+		const input = `"value": "x-client-data=abc123&api-key=secret"`;
+		const keys = extractInlineKvKeys(input);
+		expect(keys).toEqual(["api-key", "x-client-data"]);
+	});
+});
+
+describe("getHarInfo", () => {
+	it("extracts inlineKvPairs from HAR content", () => {
+		const har = JSON.stringify({
+			log: {
+				entries: [
+					{
+						request: {
+							headers: [
+								{
+									name: "X-Custom-Auth",
+									value: "client_secret=mysupersecret&client_id=app123",
+								},
+							],
+							cookies: [],
+							queryString: [],
+						},
+						response: {
+							headers: [],
+							cookies: [],
+							content: { mimeType: "application/json" },
+						},
+					},
+				],
+			},
+		});
+		const info = getHarInfo(har);
+		expect(info.inlineKvPairs).toContain("client_secret");
+		expect(info.inlineKvPairs).toContain("client_id");
+	});
+});
+
+describe("sanitize", () => {
+	it("sanitizes inline key=value pairs with default scrub words", () => {
+		const har = JSON.stringify({
+			log: {
+				entries: [
+					{
+						request: {
+							headers: [
+								{
+									name: "X-Custom-Auth",
+									value: "client_secret=mysupersecret&client_id=app123",
+								},
+							],
+							cookies: [],
+							queryString: [],
+						},
+						response: {
+							headers: [],
+							cookies: [],
+							content: { mimeType: "application/json" },
+						},
+					},
+				],
+			},
+		});
+
+		const result = sanitize(har, {
+			scrubWords: ["client_secret", "client_id"],
+		});
+
+		expect(result).toContain("[client_secret redacted]");
+		expect(result).toContain("[client_id redacted]");
+		expect(result).not.toContain("mysupersecret");
+		expect(result).not.toContain("app123");
+	});
+
+	it("uses defaultScrubItems when scrubWords is empty array", () => {
+		const har = JSON.stringify({
+			log: {
+				entries: [
+					{
+						request: {
+							headers: [{ name: "Authorization", value: "Bearer token123" }],
+							cookies: [],
+							queryString: [],
+						},
+						response: {
+							headers: [],
+							cookies: [],
+							content: { mimeType: "application/json" },
+						},
+					},
+				],
+			},
+		});
+
+		const result = sanitize(har, { scrubWords: [] });
+		expect(result).toContain("[Authorization redacted]");
+	});
+});


### PR DESCRIPTION
The regex for `[full word]=[capture]` already sanitizes inline KV pairs, but `getHarInfo()` only extracted structured JSON fields, missing keys embedded in string values (e.g., "client_secret=xxx&client_id=yyy").

- Add `extractInlineKvKeys()` to populate `inlineKvPairs` in `getHarInfo()`
- Add "Inline Key Value Pairs" section in UI
- Fix empty array check in `getScrubWords()` (`[]` is truthy in JS)
- Add simple tests for HAR sanitization

<img width="1214" height="658" alt="image" src="https://github.com/user-attachments/assets/37add561-af74-4245-9e0c-6dfc58bb4845" />


closes #66 